### PR TITLE
node server: changes to get it working under Termux

### DIFF
--- a/node-server/gm-node-config.h
+++ b/node-server/gm-node-config.h
@@ -33,8 +33,9 @@
 // #define PROC_LIMIT 128
 
 // temp file names
-#define TEMP_PREFIX "/tmp/gridmii-"
-#define TEMP_PATTERN TEMP_PREFIX "XXXXXX"
-#define TEMP_NAME_SIZE sizeof(TEMP_PATTERN)
+#define TEMP_PATTERN "XXXXXX"
+
+// should be reasonable with any TMPDIR
+#define MAX_TEMP_NAME_SIZE 80
 
 #endif

--- a/node-server/gm-node.h
+++ b/node-server/gm-node.h
@@ -22,6 +22,8 @@ struct gm_config_data {
     const char *node_name;      // name of node in the grid
     const char *job_cwd;        // starting directory for jobs
     const char *job_shell;      // shell used to run job script
+    const char *tmpdir;         // temporary directory
+    int tmp_name_size;          // temporary filename size
 };
 
 // global configuration table
@@ -78,7 +80,7 @@ struct job {
     int exit_stat;                  // exit status as returned by waitpid
     write_callback on_write;        // called when the process writes to stdout/stderr
     size_t stdout_sent;             // bytes already sent from stdout to MQTT
-    char temp_path[TEMP_NAME_SIZE]; // path to the job script
+    char temp_path[MAX_TEMP_NAME_SIZE]; // path to the job script
 };
 
 // initialize the job table

--- a/node-server/start_node.sh
+++ b/node-server/start_node.sh
@@ -33,5 +33,19 @@ else
         echo 'Try running `make` or `gmake`.'
         exit 1
     fi
+    if [ "$TMPDIR" = "" ]
+    then
+        echo 'Your $TMPDIR environment variable appears to be empty.  A default value of /tmp/ will be used.'
+	# ensure that it's really unset
+	unset TMPDIR
+    fi
+
+    # if it's an empty but set string, that's fatal to the server - complain
+    if [ "$GRID_NODE_NAME" = "" ]
+    then
+        echo 'Your $GRID_NODE_NAME environment variable appears to be empty.  It must contain a valid value for the node server to start.'
+	echo 'Please assign $GRID_NODE_NAME a non-empty value.'
+	exit 1
+    fi
     exec $NODE_BIN
 fi


### PR DESCRIPTION
Use the system TMPDIR environment variable rather than assuming /tmp. Also, some general cleanup, like removing the dead spawn.h includes, and making start_node.sh enforce a valid node name.