### PR TITLE
node-server: add stdint.h to gm-node.h

### DIFF
--- a/node-server/gm-node.h
+++ b/node-server/gm-node.h
@@ -1,5 +1,6 @@
 // gm-node.h - global declarations for gridmii node server
 
+#include <stdint.h>
 #include <sys/types.h>
 #include <mosquitto.h>
 #include <jansson.h>


### PR DESCRIPTION
Since it uses `uint32_t`, it's required.  It's only worked by chance so far, officially you need to include stdint.h