### PR TITLE
node-server: stop using strnlen

### DIFF
--- a/node-server/jobs.c
+++ b/node-server/jobs.c
@@ -481,7 +481,10 @@ int submit_job(jid_t jid, write_callback on_write, const char *command) {
         warn("could not create temp file for job script");
         return rv;
     }
-    int buf_len = strnlen(command, JOB_SCRIPT_LIMIT);
+    int buf_len = strlen(command);
+    if (buf_len > JOB_SCRIPT_LIMIT) {
+        buf_len = JOB_SCRIPT_LIMIT;
+    }
     write(scriptfd, command, buf_len);
     write(scriptfd, "\n", 1);
     close(scriptfd);


### PR DESCRIPTION
It's not C99 compatible, and needs to be dropped to work on old OSX.